### PR TITLE
Fix coroutine 'TCPConnector.close' was never awaited error

### DIFF
--- a/cent/client/session/aiohttp.py
+++ b/cent/client/session/aiohttp.py
@@ -64,5 +64,7 @@ class AiohttpSession(BaseHttpAsyncSession):
     def __del__(self) -> None:
         if self._session and not self._session.closed:
             if self._session.connector is not None and self._session.connector_owner:
-                self._session.connector.close()
+                # Use synchronous close to avoid "coroutine was never awaited" warning
+                # https://github.com/aio-libs/aiohttp/blob/cfdafac20c10b849f6e6d1794b7168e545668878/aiohttp/connector.py#L326
+                self._session.connector._close_immediately()
             self._session._connector = None

--- a/cent/client/session/aiohttp.py
+++ b/cent/client/session/aiohttp.py
@@ -60,11 +60,3 @@ class AiohttpSession(BaseHttpAsyncSession):
             ) from error
         self.check_status_code(status_code=resp.status)
         return raw_result
-
-    def __del__(self) -> None:
-        if self._session and not self._session.closed:
-            if self._session.connector is not None and self._session.connector_owner:
-                # Use synchronous close to avoid "coroutine was never awaited" warning
-                # https://github.com/aio-libs/aiohttp/blob/cfdafac20c10b849f6e6d1794b7168e545668878/aiohttp/connector.py#L326
-                self._session.connector._close_immediately()
-            self._session._connector = None


### PR DESCRIPTION
I was getting `site-packages/cent/client/session/aiohttp.py:67: RuntimeWarning: coroutine 'TCPConnector.close' was never awaited self._session.connector.close()` in my logs.

This warning occurs because AiohttpSession.__del__ attempts to call self._session.connector.close(), which is an asynchronous method, from a synchronous context. I've checked aiohttp source code and they use [synchronous _close_immediately()](https://github.com/aio-libs/aiohttp/blob/cfdafac20c10b849f6e6d1794b7168e545668878/aiohttp/connector.py#L326) there.